### PR TITLE
sync mandates and leidingevenden

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,25 @@ Start the system:
 ```shell
 docker-compose up
 ```
+
+### Sync data from digitaal loket (Mandaten en Leidingevenden)
+
+Set up a sync to load Mandaten en Leidingevenden from a Digitaal Loket instance to Digitaal Loket Data Warehouse with the [delta-consumer](https://github.com/lblod/delta-consumer).
+
+An example `docker-compose.override.yml` configuration. See [delta-consumer](https://github.com/lblod/delta-consumer) for more info.
+
+```
+version: '3.7'
+
+services:
+  mandatendatabank-consumer:
+    environment:
+      DCR_SYNC_BASE_URL: 'https://my-digital-loket-instance.net'
+      DCR_DISABLE_INITIAL_SYNC: 'false'
+      BATCH_SIZE: 1000
+  leidinggevenden-consumer:
+    environment:
+      DCR_SYNC_BASE_URL: 'https://my-digital-loket-instance.net'
+      DCR_DISABLE_INITIAL_SYNC: 'false'
+      BATCH_SIZE: 1000
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,3 +36,41 @@ services:
       - database:database
     volumes:
       - ./config/migrations:/data/migrations
+  mandatendatabank-consumer:
+      image: lblod/delta-consumer:0.0.5
+      environment:
+        DCR_SYNC_BASE_URL: 'https://loket.lblod.info/'
+        DCR_SERVICE_NAME: 'mandatendatabank-consumer'
+        DCR_SYNC_FILES_PATH: '/sync/mandatarissen/files'
+        DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/MandatarissenCacheGraphDump"
+        DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/mandatarissen"
+        DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/deltaSync/mandatarissen"
+        DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/mandatendatabank-consumer"
+        DCR_DISABLE_INITIAL_SYNC: 'true'
+        DCR_BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: 'true'
+        DCR_KEEP_DELTA_FILES: 'true'
+        DCR_DELTA_FILE_FOLDER: '/consumer-files'
+      volumes:
+        - ./data/files/consumer-files/mandaten:/consumer-files/
+      restart: always
+      labels:
+        - "logging=true"
+  leidinggevenden-consumer:
+    image: lblod/delta-consumer:0.0.5
+    environment:
+      DCR_SYNC_BASE_URL: 'https://loket.lblod.info' # replace with link to Loket API
+      DCR_SERVICE_NAME: 'leidinggevenden-consumer'
+      DCR_SYNC_FILES_PATH: '/sync/leidinggevenden/files'
+      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/LeidinggevendenCacheGraphDump"
+      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/leidinggevenden"
+      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/deltaSync/leidinggevenden"
+      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/leidinggevenden-consumer"
+      DCR_DISABLE_INITIAL_SYNC: 'true'
+      DCR_BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: 'true'
+      DCR_KEEP_DELTA_FILES: 'true'
+      DCR_DELTA_FILE_FOLDER: '/consumer-files'
+    volumes:
+      - ./data/files/consumer-files/leidinggevenden:/consumer-files/
+    restart: always
+    labels:
+      - "logging=true"  


### PR DESCRIPTION
Consumers mandates and leidingevenden from loket.

example `docker-compose.override.yml`

```
  mandatendatabank-consumer:
    environment:
      DCR_SYNC_BASE_URL: 'https://dev.loket.lblod.info'
      DCR_DISABLE_INITIAL_SYNC: 'false'
      BATCH_SIZE: 1000
  leidinggevenden-consumer:
    environment:
      DCR_SYNC_BASE_URL: 'https://dev.loket.lblod.info'
      DCR_DISABLE_INITIAL_SYNC: 'false'
      BATCH_SIZE: 1000
```