### PR TITLE
Add pro-active data monitoring

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -25,6 +25,13 @@
 (in-package :acl)
 
 (define-prefixes
+  :mon "http://lblod.data.gift/vocabularies/monitoring/"
+  :nmo "http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#"
+  :nfo "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#"
+  :nie "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#"
+  :cogs "http://vocab.deri.ie/cogs#"
+  :task "http://redpencil.data.gift/vocabularies/tasks/"
+  :oslc "http://open-services.net/ns/core#"
   :ext "http://mu.semte.ch/vocabularies/ext/"
   :besluit "http://data.vlaanderen.be/ns/besluit#"
   :employee "http://lblod.data.gift/vocabularies/employee/"
@@ -87,6 +94,23 @@
    ("prov:Location" -> _)
    ("ext:GeslachtCode" -> _))
 
+(define-graph monitoring-graph ("http://mu.semte.ch/graphs/system/monitoring")
+  ("mon:MonitoringRun" -> _)
+  ("mon:Observation" -> _)
+  ("mon:Anomaly" -> _))
+
+(define-graph email-graph ("http://mu.semte.ch/graphs/system/email")
+  ("nmo:Email" -> _)
+  ("nmo:Mailbox" -> _)
+  ("nfo:Folder" -> _))
+
+(define-graph jobs-graph ("http://mu.semte.ch/graphs/system/jobs")
+  ("cogs:Job" -> _)
+  ("task:Task" -> _)
+  ("cogs:ScheduledJob" -> _)
+  ("task:CronSchedule" -> _)
+  ("oslc:Error" -> _))
+
 (supply-allowed-group "dwh-m2m"
   :query "PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
           PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -126,4 +150,18 @@
 (with-scope "service:m2m-login"
   (grant (read write)
          :to session-graph
+         :for "public"))
+
+(with-scope "service:data-monitoring"
+  (grant (read)
+         :to dwh-reporting
+         :for "public")
+  (grant (read write)
+         :to monitoring-graph
+         :for "public")
+  (grant (read write)
+         :to jobs-graph
+         :for "public")
+  (grant (read write)
+         :to email-graph
          :for "public"))

--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -108,6 +108,7 @@
   ("cogs:Job" -> _)
   ("task:Task" -> _)
   ("cogs:ScheduledJob" -> _)
+  ("task:ScheduledTask" -> _)
   ("task:CronSchedule" -> _)
   ("oslc:Error" -> _))
 

--- a/config/data-monitoring/queries/ABI-1378-OrgEenheden.sparql
+++ b/config/data-monitoring/queries/ABI-1378-OrgEenheden.sparql
@@ -1,0 +1,24 @@
+# https://binnenland.atlassian.net/browse/ABI-1378
+PREFIX skos:      <http://www.w3.org/2004/02/skos/core#>
+PREFIX org:       <http://www.w3.org/ns/org#>
+PREFIX voc:       <http://mu.semte.ch/vocabularies/core/>
+PREFIX reorg:     <http://www.w3.org/ns/regorg#>
+PREFIX eredienst: <http://data.lblod.info/vocabularies/erediensten/>
+
+SELECT DISTINCT
+  ?OrgEenheidUri
+  ?OrgEenheidID
+  ?OrgEenheidLabel
+  ?OrgTypeUri
+  ?OrgEenheidStatus
+  ?OrgEenheidTypeEredienst
+  ?grensoverschrijdend
+WHERE {
+  ?OrgEenheidUri org:classification ?OrgTypeUri .
+  ?OrgEenheidUri voc:uuid ?OrgEenheidID .
+
+  OPTIONAL { ?OrgEenheidUri skos:prefLabel ?OrgEenheidLabel . }
+  OPTIONAL { ?OrgEenheidUri reorg:orgStatus ?OrgEenheidStatus . }
+  OPTIONAL { ?OrgEenheidUri eredienst:typeEredienst ?OrgEenheidTypeEredienst . }
+  OPTIONAL { ?OrgEenheidUri eredienst:grensoverschrijdend ?grensoverschrijdend . }
+}

--- a/config/data-monitoring/queries/ABI-1379-Gelinkte-organisaties-niet-nodig.sparql
+++ b/config/data-monitoring/queries/ABI-1379-Gelinkte-organisaties-niet-nodig.sparql
@@ -1,0 +1,10 @@
+# https://binnenland.atlassian.net/browse/ABI-1379
+# Note: BestuurtOrgEenheidUri is not bound (not used in where clause - removed it)
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX org:  <http://www.w3.org/ns/org#>
+
+SELECT DISTINCT ?OrgEenheidUri ?GelinkteOrgEenheidUri
+WHERE {
+  ?OrgEenheidUri org:classification ?OrgTypeUri .
+  ?OrgEenheidUri org:linkedTo ?GelinkteOrgEenheidUri .
+}

--- a/config/data-monitoring/queries/ABI-1380-Betrokkenheidbestuur.sparql
+++ b/config/data-monitoring/queries/ABI-1380-Betrokkenheidbestuur.sparql
@@ -1,0 +1,22 @@
+# https://binnenland.atlassian.net/browse/ABI-1380
+PREFIX vocEre: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX org:    <http://www.w3.org/ns/org#>
+
+SELECT DISTINCT
+  ?betrokkenLokaleBesturenURI
+  ?OrgEenheidUri
+  ?betrokkenOrgEenheidURI
+  ?typeBetrokkenheidURI
+  ?financieringspercentage
+WHERE {
+  ?betrokkenLokaleBesturenURI
+    a vocEre:BetrokkenLokaleBesturen ;
+    org:organization ?OrgEenheidUri ;
+    vocEre:typebetrokkenheid ?typeBetrokkenheidURI .
+
+  OPTIONAL {
+    ?betrokkenLokaleBesturenURI vocEre:financieringspercentage ?financieringspercentage .
+  }
+
+  ?betrokkenOrgEenheidURI vocEre:betrokkenBestuur ?betrokkenLokaleBesturenURI .
+}

--- a/config/data-monitoring/queries/ABI-1380-TypeBetrokkenheid.sparql
+++ b/config/data-monitoring/queries/ABI-1380-TypeBetrokkenheid.sparql
@@ -1,0 +1,11 @@
+# https://binnenland.atlassian.net/browse/ABI-1380
+# No results on DWH endpoint
+PREFIX ere:  <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?typeBetrokkenheidURI ?typeBetrokkenheidLabel
+WHERE {
+  ?blb a ere:BetrokkenLokaleBesturen ;
+       ere:typebetrokkenheid ?typeBetrokkenheidURI .
+  ?typeBetrokkenheidURI skos:prefLabel ?typeBetrokkenheidLabel .
+}

--- a/config/data-monitoring/queries/ABI-1381-Bedienaar-met-persoonsgegevens.sparql
+++ b/config/data-monitoring/queries/ABI-1381-Bedienaar-met-persoonsgegevens.sparql
@@ -1,0 +1,60 @@
+# https://binnenland.atlassian.net/browse/ABI-1381
+# Full version with person details (see ABI-1399-Persoon.sparql for a standalone person query)
+# Note: ?structuredIdentifier should be added to the select clause?
+PREFIX besluit:  <http://data.vlaanderen.be/ns/besluit#>
+PREFIX vocEre:   <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX vocOrg:   <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX org:      <http://www.w3.org/ns/org#>
+PREFIX contact:  <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX skos:     <http://www.w3.org/2004/02/skos/core#>
+PREFIX person:   <http://www.w3.org/ns/person#>
+PREFIX persoon:  <http://data.vlaanderen.be/ns/persoon#>
+PREFIX foaf:     <http://xmlns.com/foaf/0.1/>
+PREFIX adms:     <http://www.w3.org/ns/adms#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+SELECT DISTINCT
+  ?OrgEenheidUri
+  ?positie
+  ?functie
+  ?functieLabel
+  ?bedienaar
+  ?start
+  ?einde
+  ?persoon
+  ?voornaam
+  ?naam
+  ?nationaliteit
+  ?identifier
+WHERE {
+  ?OrgEenheidUri a besluit:Bestuurseenheid ;
+    vocEre:wordtBediendDoor ?positie .
+
+  ?positie a vocEre:PositieBedienaar ;
+    vocEre:functie ?functie .
+
+  ?bedienaar a vocEre:RolBedienaar ;
+    org:heldBy ?persoon ;
+    contact:startdatum ?start ;
+    org:holds ?positie .
+
+  OPTIONAL {
+    ?functie a vocOrg:EredienstBeroepen ;
+      skos:prefLabel ?functieLabel .
+  }
+
+  OPTIONAL { ?bedienaar contact:eindedatum ?einde . }
+
+  OPTIONAL {
+    ?persoon a person:Person ;
+      persoon:gebruikteVoornaam ?voornaam ;
+      foaf:familyName ?naam ;
+      adms:identifier ?identifier .
+    ?identifier a adms:Identifier ;
+      generiek:gestructureerdeIdentificator ?structuredIdentifier .
+  }
+
+  OPTIONAL {
+    ?persoon persoon:heeftNationaliteit ?nationaliteit .
+  }
+}

--- a/config/data-monitoring/queries/ABI-1381-Bedienaar.sparql
+++ b/config/data-monitoring/queries/ABI-1381-Bedienaar.sparql
@@ -1,0 +1,37 @@
+# https://binnenland.atlassian.net/browse/ABI-1381
+# Note: person details (voornaam, naam, nationaliteit, identifier) are in ABI-1399-Persoon.sparql
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX vocEre:  <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX vocOrg:  <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX org:     <http://www.w3.org/ns/org#>
+PREFIX contact: <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT
+  ?OrgEenheidUri
+  ?positie
+  ?functie
+  ?functieLabel
+  ?bedienaar
+  ?start
+  ?einde
+  ?persoon
+WHERE {
+  ?OrgEenheidUri a besluit:Bestuurseenheid ;
+    vocEre:wordtBediendDoor ?positie .
+
+  ?positie a vocEre:PositieBedienaar ;
+    vocEre:functie ?functie .
+
+  ?bedienaar a vocEre:RolBedienaar ;
+    org:heldBy ?persoon ;
+    contact:startdatum ?start ;
+    org:holds ?positie .
+
+  OPTIONAL {
+    ?functie a vocOrg:EredienstBeroepen ;
+      skos:prefLabel ?functieLabel .
+  }
+
+  OPTIONAL { ?bedienaar contact:eindedatum ?einde . }
+}

--- a/config/data-monitoring/queries/ABI-1382-Events.sparql
+++ b/config/data-monitoring/queries/ABI-1382-Events.sparql
@@ -1,0 +1,21 @@
+# https://binnenland.atlassian.net/browse/ABI-1382
+# Note: made sure at least on triple pattern is outside the optional block.
+PREFIX ch:   <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX org:  <http://www.w3.org/ns/org#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dct:  <http://purl.org/dc/terms/>
+
+SELECT DISTINCT
+  ?OrgEenheidUri
+  ?changeEvent
+  ?changeTypeLabel
+  ?changeEventDate
+WHERE {
+  ?changeEvent a org:ChangeEvent .
+  OPTIONAL {
+    ?changeEvent org:resultingOrganization ?OrgEenheidUri ;
+      dct:date ?changeEventDate ;
+      ch:typeWijziging ?changeTypeURI .
+    ?changeTypeURI skos:prefLabel ?changeTypeLabel .
+  }
+}

--- a/config/data-monitoring/queries/ABI-1383-OrgTypes.sparql
+++ b/config/data-monitoring/queries/ABI-1383-OrgTypes.sparql
@@ -1,0 +1,20 @@
+# https://binnenland.atlassian.net/browse/ABI-1383
+# Adminlabel not used? commented it out.
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX org:  <http://www.w3.org/ns/org#>
+
+SELECT DISTINCT
+  ?classificationURI
+  ?classificationLabel
+WHERE {
+  ?adminUnit org:classification ?classificationURI .
+
+  # OPTIONAL { ?adminUnit skos:prefLabel ?adminLabel . }
+
+  ?classificationURI skos:prefLabel ?classificationLabel .
+
+  FILTER (
+    lang(?classificationLabel) = "" ||
+    langMatches(lang(?classificationLabel), "nl")
+  )
+}

--- a/config/data-monitoring/queries/ABI-1384-Status.sparql
+++ b/config/data-monitoring/queries/ABI-1384-Status.sparql
@@ -1,0 +1,11 @@
+# https://binnenland.atlassian.net/browse/ABI-1384
+PREFIX rov:  <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?status ?label
+WHERE {
+  ?org rov:orgStatus ?status .
+
+  OPTIONAL { ?status skos:prefLabel ?label . }
+}

--- a/config/data-monitoring/queries/ABI-1385-TypeEredienst.sparql
+++ b/config/data-monitoring/queries/ABI-1385-TypeEredienst.sparql
@@ -1,0 +1,9 @@
+# https://binnenland.atlassian.net/browse/ABI-1385
+PREFIX er:   <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?typeEredienst ?label
+WHERE {
+  ?eenheid er:typeEredienst ?typeEredienst .
+  ?typeEredienst skos:prefLabel ?label .
+}

--- a/config/data-monitoring/queries/ABI-1386-Werkingsgebied.sparql
+++ b/config/data-monitoring/queries/ABI-1386-Werkingsgebied.sparql
@@ -1,0 +1,12 @@
+# https://binnenland.atlassian.net/browse/ABI-1386
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT DISTINCT ?werkingsgebied ?label ?werkingsgebiedNiveau
+WHERE {
+  ?s besluit:werkingsgebied ?werkingsgebied .
+
+  OPTIONAL { ?werkingsgebied rdfs:label ?label . }
+  OPTIONAL { ?werkingsgebied ext:werkingsgebiedNiveau ?werkingsgebiedNiveau . }
+}

--- a/config/data-monitoring/queries/ABI-1387-Adres.sparql
+++ b/config/data-monitoring/queries/ABI-1387-Adres.sparql
@@ -1,0 +1,32 @@
+# https://binnenland.atlassian.net/browse/ABI-1387
+# Note:
+#  - made sure at least on triple pattern is outside the optional block.
+#  - Will return results is e.g. postcode is missing, but a province is available. (before it was all or nothing)
+PREFIX org:          <http://www.w3.org/ns/org#>
+PREFIX locn:         <http://www.w3.org/ns/locn#>
+PREFIX organisatie:  <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX adms:         <http://www.w3.org/ns/adms#>
+PREFIX generiek:     <https://data.vlaanderen.be/ns/generiek#>
+PREFIX adres:        <https://data.vlaanderen.be/ns/adres#>
+PREFIX ch:           <http://data.lblod.info/vocabularies/contacthub/>
+
+SELECT DISTINCT
+  ?OrgEenheidUri
+  ?province
+  ?gemeente
+  ?postcode
+WHERE {
+  ?OrgEenheidUri org:hasPrimarySite ?site .
+  OPTIONAL {
+    ?site organisatie:bestaatUit ?address .
+    OPTIONAL {
+       ?address locn:adminUnitL2 ?province .
+    }
+    OPTIONAL {
+      ?address locn:postCode ?postcode .
+    }
+    OPTIONAL {
+      ?address adres:gemeentenaam ?gemeente .
+    }
+  }
+}

--- a/config/data-monitoring/queries/ABI-1388-Bestuurshierarchy-AdminUnitLokaalBestuur.sparql
+++ b/config/data-monitoring/queries/ABI-1388-Bestuurshierarchy-AdminUnitLokaalBestuur.sparql
@@ -1,0 +1,11 @@
+# https://binnenland.atlassian.net/browse/ABI-1388
+# Query 3: AdminUnit / LokaalBestuur
+PREFIX org:     <http://www.w3.org/ns/org#>
+PREFIX bestuur: <http://data.lblod.info/vocabularies/erediensten/>
+
+SELECT DISTINCT ?OrgEenheidUri ?AdminUnitURI ?LokaalBestuurURI
+WHERE {
+  ?AdminUnitURI org:organization ?OrgEenheidUri .
+
+  OPTIONAL { ?LokaalBestuurURI bestuur:betrokkenBestuur ?AdminUnitURI . }
+}

--- a/config/data-monitoring/queries/ABI-1388-Bestuurshierarchy-Governance.sparql
+++ b/config/data-monitoring/queries/ABI-1388-Bestuurshierarchy-Governance.sparql
@@ -1,0 +1,20 @@
+# https://binnenland.atlassian.net/browse/ABI-1388
+# Combines original queries 1 (Bestuurt/GoverningBody), 2 (RepresentativeBody),
+# and the original combined query -- anchored on OrgEenheid to avoid full store scan.
+# Query 3 (AdminUnit/LokaalBestuur) is kept separate below.
+# Query 4 (BetrokkenLokaalBestuur) is already covered by ABI-1380.
+PREFIX org:     <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+SELECT DISTINCT
+  ?OrgEenheidUri
+  ?BestuurtURI
+  ?GoverningBodyURI
+  ?RepresentativeBodyURI
+WHERE {
+  ?OrgEenheidUri org:classification ?type .
+
+  OPTIONAL { ?BestuurtURI besluit:bestuurt ?OrgEenheidUri . }
+  OPTIONAL { ?GoverningBodyURI org:hasSubOrganization ?OrgEenheidUri . }
+  OPTIONAL { ?RepresentativeBodyURI org:linkedTo ?OrgEenheidUri . }
+}

--- a/config/data-monitoring/queries/ABI-1388-Bestuurshierarchy-Lidmaatschap.sparql
+++ b/config/data-monitoring/queries/ABI-1388-Bestuurshierarchy-Lidmaatschap.sparql
@@ -1,0 +1,16 @@
+# https://binnenland.atlassian.net/browse/ABI-1388
+# Query 5: Lidmaatschap
+PREFIX org: <http://www.w3.org/ns/org#>
+
+SELECT DISTINCT
+  ?lidmaatschap
+  ?OrgEenheidUri
+  ?member
+  ?role
+WHERE {
+  ?lidmaatschap a org:Membership ;
+    org:organization ?OrgEenheidUri ;
+    org:member ?member .
+
+  OPTIONAL { ?lidmaatschap org:role ?role . }
+}

--- a/config/data-monitoring/queries/ABI-1389-Functies-no-result-on-DWH.sparql
+++ b/config/data-monitoring/queries/ABI-1389-Functies-no-result-on-DWH.sparql
@@ -1,0 +1,10 @@
+# https://binnenland.atlassian.net/browse/ABI-1389
+PREFIX er:   <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?functie ?functieLabel
+WHERE {
+  ?bestuur   er:wordtBediendDoor ?bedienaar .
+  ?bedienaar er:functie ?functie .
+  ?functie   skos:prefLabel ?functieLabel .
+}

--- a/config/data-monitoring/queries/ABI-1390-BestuurorgaanWerkingsgebied.sparql
+++ b/config/data-monitoring/queries/ABI-1390-BestuurorgaanWerkingsgebied.sparql
@@ -1,0 +1,9 @@
+# https://binnenland.atlassian.net/browse/ABI-1390
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+SELECT DISTINCT
+  ?BestuursorgaanURI
+  ?WerkingsgebiedURI
+WHERE {
+  ?BestuursorgaanURI besluit:werkingsgebied ?WerkingsgebiedURI .
+}

--- a/config/data-monitoring/queries/ABI-1391-Bestuursorgaan.sparql
+++ b/config/data-monitoring/queries/ABI-1391-Bestuursorgaan.sparql
@@ -1,0 +1,24 @@
+# https://binnenland.atlassian.net/browse/ABI-1391
+PREFIX org:     <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX gen:     <https://data.vlaanderen.be/ns/generiek#>
+
+SELECT DISTINCT
+  ?bestuursorgaan
+  ?isTijdspecialisatieVan
+  ?bindingStart
+  ?bindingEinde
+  ?mandaat
+WHERE {
+  ?bestuursorgaan a besluit:Bestuursorgaan .
+
+  { ?bestuursorgaan gen:isTijdspecialisatieVan ?isTijdspecialisatieVan . }
+  UNION
+  { ?bestuursorgaan mandaat:isTijdspecialisatieVan ?isTijdspecialisatieVan . }
+
+  OPTIONAL { ?bestuursorgaan mandaat:bindingStart ?bindingStart . }
+  OPTIONAL { ?bestuursorgaan mandaat:bindingEinde ?bindingEinde . }
+
+  ?bestuursorgaan org:hasPost ?mandaat .
+}

--- a/config/data-monitoring/queries/ABI-1392-MandaatRole.sparql
+++ b/config/data-monitoring/queries/ABI-1392-MandaatRole.sparql
@@ -1,0 +1,12 @@
+# https://binnenland.atlassian.net/browse/ABI-1392
+PREFIX org:  <http://www.w3.org/ns/org#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT
+  ?role
+  ?label
+WHERE {
+  ?something org:role ?role .
+
+  OPTIONAL { ?role skos:prefLabel ?label . }
+}

--- a/config/data-monitoring/queries/ABI-1393-Mandataris.sparql
+++ b/config/data-monitoring/queries/ABI-1393-Mandataris.sparql
@@ -1,0 +1,42 @@
+# https://binnenland.atlassian.net/browse/ABI-1393
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org:     <http://www.w3.org/ns/org#>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX person:  <http://www.w3.org/ns/person#>
+PREFIX persoon: <http://data.vlaanderen.be/ns/persoon#>
+PREFIX ere:     <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX owl:     <http://www.w3.org/2002/07/owl#>
+
+SELECT DISTINCT
+  ?OrgEenheidUri
+  ?mandaat
+  ?role
+  ?rolename
+  ?mandataris
+  ?status
+  ?startDate
+  ?endDate
+  ?plannedEndDate
+  ?persoon
+WHERE {
+  ?bestuurInTijd a besluit:Bestuursorgaan ;
+    org:hasPost ?mandaat ;
+    mandaat:isTijdspecialisatieVan ?bestuur .
+
+  ?bestuur besluit:bestuurt ?OrgEenheidUri .
+
+  ?mandaat a mandaat:Mandaat ;
+    org:role ?role ;
+    org:heldBy ?mandataris .
+
+  ?role skos:prefLabel ?rolename .
+
+  ?mandataris mandaat:status ?status ;
+    mandaat:start ?startDate .
+
+  OPTIONAL { ?mandataris mandaat:einde ?endDate . }
+  OPTIONAL { ?mandataris ere:geplandeEinddatumAanstelling ?plannedEndDate . }
+
+  ?mandataris mandaat:isBestuurlijkeAliasVan ?persoon .
+}

--- a/config/data-monitoring/queries/ABI-1394-Submissions-impacted-org.sparql
+++ b/config/data-monitoring/queries/ABI-1394-Submissions-impacted-org.sparql
@@ -1,0 +1,43 @@
+# https://binnenland.atlassian.net/browse/ABI-1394
+# Added ImpactedOrgEenheidUri via eli:is_about on FormData
+PREFIX nmo:     <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+PREFIX adms:    <http://www.w3.org/ns/adms#>
+PREFIX pav:     <http://purl.org/pav/>
+PREFIX prov:    <http://www.w3.org/ns/prov#>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX eli:     <http://data.europa.eu/eli/ontology#>
+PREFIX dct:     <http://purl.org/dc/terms/>
+PREFIX meb:     <http://rdf.myexperiment.org/ontologies/base/>
+PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT DISTINCT
+  ?inzending
+  ?OrgEenheidUri
+  ?ImpactedOrgEenheidUri
+  ?datumZitting
+  ?datumVerzending
+  ?typeBesluitLabel
+  ?statusURI
+  ?statusLabel
+WHERE {
+  ?inzending a meb:Submission ;
+    pav:createdBy ?OrgEenheidUri ;
+    nmo:sentDate ?datumVerzending ;
+    adms:status ?statusURI ;
+    prov:generated ?formulier .
+
+  OPTIONAL { ?statusURI skos:prefLabel ?statusLabel . }
+
+  ?formulier a melding:FormData ;
+    ext:sessionStartedAtTime ?datumZitting ;
+    eli:passed_by ?orgaanInTijd .
+
+  OPTIONAL { ?formulier eli:is_about ?ImpactedOrgEenheidUri . }
+
+  OPTIONAL {
+    ?formulier dct:type ?typeBesluit .
+    ?typeBesluit skos:prefLabel ?typeBesluitLabel .
+  }
+}

--- a/config/data-monitoring/queries/ABI-1394-Submissions.sparql
+++ b/config/data-monitoring/queries/ABI-1394-Submissions.sparql
@@ -1,0 +1,40 @@
+# https://binnenland.atlassian.net/browse/ABI-1394
+# Note: orgaanInTijd not used?
+PREFIX nmo:     <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+PREFIX adms:    <http://www.w3.org/ns/adms#>
+PREFIX pav:     <http://purl.org/pav/>
+PREFIX prov:    <http://www.w3.org/ns/prov#>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX eli:     <http://data.europa.eu/eli/ontology#>
+PREFIX dct:     <http://purl.org/dc/terms/>
+PREFIX meb:     <http://rdf.myexperiment.org/ontologies/base/>
+PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT DISTINCT
+  ?inzending
+  ?OrgEenheidUri
+  ?datumZitting
+  ?datumVerzending
+  ?typeBesluitLabel
+  ?statusURI
+  ?statusLabel
+WHERE {
+  ?inzending a meb:Submission ;
+    pav:createdBy ?OrgEenheidUri ;
+    nmo:sentDate ?datumVerzending ;
+    adms:status ?statusURI ;
+    prov:generated ?formulier .
+
+  OPTIONAL { ?statusURI skos:prefLabel ?statusLabel . }
+
+  ?formulier a melding:FormData ;
+    ext:sessionStartedAtTime ?datumZitting ;
+    eli:passed_by ?orgaanInTijd .
+
+  OPTIONAL {
+    ?formulier dct:type ?typeBesluit .
+    ?typeBesluit skos:prefLabel ?typeBesluitLabel .
+  }
+}

--- a/config/data-monitoring/queries/ABI-1396-ChangeEvents.sparql
+++ b/config/data-monitoring/queries/ABI-1396-ChangeEvents.sparql
@@ -1,0 +1,24 @@
+# https://binnenland.atlassian.net/browse/ABI-1396
+# Note: eenheid and changeevent were not connected: cartesian product
+# Since it was not used in the select, I've just commented it out
+PREFIX ch:      <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX org:     <http://www.w3.org/ns/org#>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX dct:     <http://purl.org/dc/terms/>
+
+SELECT DISTINCT
+  ?OrgEenheidUri
+  ?changeEvent
+  ?changeTypeLabel
+  ?changeEventDate
+WHERE {
+  # ?eenheid skos:prefLabel ?eenheidLabel ;
+  #   besluit:classificatie ?eenheidClassificatie .
+
+  ?changeEvent org:resultingOrganization ?OrgEenheidUri ;
+    dct:date ?changeEventDate ;
+    ch:typeWijziging ?changeTypeURI .
+
+  ?changeTypeURI skos:prefLabel ?changeTypeLabel .
+}

--- a/config/data-monitoring/queries/ABI-1397-MandatarisStatus.sparql
+++ b/config/data-monitoring/queries/ABI-1397-MandatarisStatus.sparql
@@ -1,0 +1,14 @@
+# https://binnenland.atlassian.net/browse/ABI-1397
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT
+  ?statusURI
+  ?statusLabel
+WHERE {
+  ?statusURI skos:prefLabel ?statusLabel .
+
+  FILTER(STRSTARTS(
+    STR(?statusURI),
+    "http://data.vlaanderen.be/id/concept/MandatarisStatusCode/"
+  ))
+}

--- a/config/data-monitoring/queries/ABI-1399-Persoon.sparql
+++ b/config/data-monitoring/queries/ABI-1399-Persoon.sparql
@@ -1,0 +1,39 @@
+# https://binnenland.atlassian.net/browse/ABI-1399
+# Note: fixed nationality and birth
+PREFIX person:   <http://www.w3.org/ns/person#>
+PREFIX foaf:     <http://xmlns.com/foaf/0.1/>
+PREFIX dct:      <http://purl.org/dc/terms/>
+PREFIX adms:     <http://www.w3.org/ns/adms#>
+PREFIX prov:     <http://www.w3.org/ns/prov#>
+PREFIX skos:     <http://www.w3.org/2004/02/skos/core#>
+PREFIX persoon:  <http://data.vlaanderen.be/ns/persoon#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+SELECT DISTINCT
+  ?persoon
+  ?voornaam
+  ?achternaam
+  ?geboortedatum
+  ?geslacht
+  ?nationaliteit
+WHERE {
+  ?persoon a person:Person .
+
+  OPTIONAL { ?persoon persoon:gebruikteVoornaam ?voornaam . }
+  OPTIONAL { ?persoon foaf:familyName ?achternaam . }
+
+  OPTIONAL {
+    ?persoon persoon:heeftGeboorte ?geboorteNode .
+    ?geboorteNode persoon:datum ?geboortedatum .
+  }
+
+  OPTIONAL {
+    ?persoon persoon:geslacht ?geslachtUri .
+    ?geslachtUri skos:prefLabel ?geslacht .
+  }
+
+  OPTIONAL {
+    ?persoon persoon:heeftNationaliteit ?nationaliteitUri .
+    ?nationaliteitUri skos:prefLabel ?nationaliteit .
+  }
+}

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -1,17 +1,36 @@
 export default [
-  // {
-  //   match: {
-  //     subject: { }
-  //   },
-  //   callback: {
-  //     url: "http://resource/.mu/delta",
-  //     method: "POST"
-  //   },
-  //   options: {
-  //     resourceFormat: "v0.0.1",
-  //     gracePeriod: 250,
-  //     ignoreFromSelf: true,
-  //     foldEffectiveChanges: true
-  //   }
-  // },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status',
+      },
+    },
+    callback: {
+      url: 'http://data-monitoring/delta',
+      method: 'POST',
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+    },
+  },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status',
+      },
+    },
+    callback: {
+      url: 'http://scheduled-job-controller/delta',
+      method: 'POST',
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+    },
+  },
 ];

--- a/config/migrations/20260403120000-seed-data-monitoring-scheduled-job.sparql
+++ b/config/migrations/20260403120000-seed-data-monitoring-scheduled-job.sparql
@@ -1,0 +1,18 @@
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX schema: <http://schema.org/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/system/jobs> {
+    <http://data.lblod.info/id/scheduled-job/data-monitoring>
+      a cogs:ScheduledJob ;
+      mu:uuid "data-monitoring-scheduled-job" ;
+      task:operation <http://redpencil.data.gift/id/jobs/concept/JobOperation/dataMonitoring> ;
+      task:schedule <http://data.lblod.info/id/schedule/data-monitoring> .
+
+    <http://data.lblod.info/id/schedule/data-monitoring>
+      a task:CronSchedule ;
+      schema:repeatFrequency "17 4 * * *" .
+  }
+}

--- a/config/migrations/20260403130000-seed-mailbox-folders.sparql
+++ b/config/migrations/20260403130000-seed-mailbox-folders.sparql
@@ -1,41 +1,41 @@
-PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
-PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+  PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-INSERT DATA {
-  GRAPH <http://mu.semte.ch/graphs/system/email> {
-    <http://data.lblod.info/id/mailboxes/1> a nmo:Mailbox ;
-      mu:uuid "cf9cb7e4-9a00-4855-9ee0-e8e3bbeba9e9" .
+  INSERT DATA {
+    GRAPH <http://mu.semte.ch/graphs/system/email> {
+      <http://data.lblod.info/id/mailboxes/1> a nmo:Mailbox ;
+        mu:uuid "cf9cb7e4-9a00-4855-9ee0-e8e3bbeba9e9" ;
+        nie:hasPart <http://data.lblod.info/id/mail-folders/1> ;
+        nie:hasPart <http://data.lblod.info/id/mail-folders/2> ;
+        nie:hasPart <http://data.lblod.info/id/mail-folders/3> ;
+        nie:hasPart <http://data.lblod.info/id/mail-folders/4> ;
+        nie:hasPart <http://data.lblod.info/id/mail-folders/5> ;
+        nie:hasPart <http://data.lblod.info/id/mail-folders/6> .
 
-    <http://data.lblod.info/id/mail-folders/1> a nfo:Folder ;
-      mu:uuid "2cdb2c28-3fc4-4e47-84dc-1bf1369c3a5f" ;
-      nie:title "inbox" ;
-      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+      <http://data.lblod.info/id/mail-folders/1> a nfo:Folder ;
+        mu:uuid "2cdb2c28-3fc4-4e47-84dc-1bf1369c3a5f" ;
+        nie:title "inbox" .
 
-    <http://data.lblod.info/id/mail-folders/2> a nfo:Folder ;
-      mu:uuid "6e165651-1e05-4e45-abab-21a2d0c1c383" ;
-      nie:title "outbox" ;
-      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+      <http://data.lblod.info/id/mail-folders/2> a nfo:Folder ;
+        mu:uuid "6e165651-1e05-4e45-abab-21a2d0c1c383" ;
+        nie:title "outbox" .
 
-    <http://data.lblod.info/id/mail-folders/3> a nfo:Folder ;
-      mu:uuid "7189e9a6-d14c-47b0-977e-3e70f5a515a3" ;
-      nie:title "sentbox" ;
-      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+      <http://data.lblod.info/id/mail-folders/3> a nfo:Folder ;
+        mu:uuid "7189e9a6-d14c-47b0-977e-3e70f5a515a3" ;
+        nie:title "sentbox" .
 
-    <http://data.lblod.info/id/mail-folders/4> a nfo:Folder ;
-      mu:uuid "b2e3290e-4ec9-4dba-ae38-b67893cfab35" ;
-      nie:title "sending" ;
-      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+      <http://data.lblod.info/id/mail-folders/4> a nfo:Folder ;
+        mu:uuid "b2e3290e-4ec9-4dba-ae38-b67893cfab35" ;
+        nie:title "sending" .
 
-    <http://data.lblod.info/id/mail-folders/5> a nfo:Folder ;
-      mu:uuid "a4c91ca0-79a4-4e91-8e3b-3a4ec2777adb" ;
-      nie:title "drafts" ;
-      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+      <http://data.lblod.info/id/mail-folders/5> a nfo:Folder ;
+        mu:uuid "a4c91ca0-79a4-4e91-8e3b-3a4ec2777adb" ;
+        nie:title "drafts" .
 
-    <http://data.lblod.info/id/mail-folders/6> a nfo:Folder ;
-      mu:uuid "d5a3c4e9-7f2b-4a8d-b1c6-5e9f3a2d8b7c" ;
-      nie:title "failbox" ;
-      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+      <http://data.lblod.info/id/mail-folders/6> a nfo:Folder ;
+        mu:uuid "d5a3c4e9-7f2b-4a8d-b1c6-5e9f3a2d8b7c" ;
+        nie:title "failbox" .
+    }
   }
-}

--- a/config/migrations/20260403130000-seed-mailbox-folders.sparql
+++ b/config/migrations/20260403130000-seed-mailbox-folders.sparql
@@ -1,0 +1,41 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/system/email> {
+    <http://data.lblod.info/id/mailboxes/1> a nmo:Mailbox ;
+      mu:uuid "cf9cb7e4-9a00-4855-9ee0-e8e3bbeba9e9" .
+
+    <http://data.lblod.info/id/mail-folders/1> a nfo:Folder ;
+      mu:uuid "2cdb2c28-3fc4-4e47-84dc-1bf1369c3a5f" ;
+      nie:title "inbox" ;
+      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+
+    <http://data.lblod.info/id/mail-folders/2> a nfo:Folder ;
+      mu:uuid "6e165651-1e05-4e45-abab-21a2d0c1c383" ;
+      nie:title "outbox" ;
+      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+
+    <http://data.lblod.info/id/mail-folders/3> a nfo:Folder ;
+      mu:uuid "7189e9a6-d14c-47b0-977e-3e70f5a515a3" ;
+      nie:title "sentbox" ;
+      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+
+    <http://data.lblod.info/id/mail-folders/4> a nfo:Folder ;
+      mu:uuid "b2e3290e-4ec9-4dba-ae38-b67893cfab35" ;
+      nie:title "sending" ;
+      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+
+    <http://data.lblod.info/id/mail-folders/5> a nfo:Folder ;
+      mu:uuid "a4c91ca0-79a4-4e91-8e3b-3a4ec2777adb" ;
+      nie:title "drafts" ;
+      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+
+    <http://data.lblod.info/id/mail-folders/6> a nfo:Folder ;
+      mu:uuid "d5a3c4e9-7f2b-4a8d-b1c6-5e9f3a2d8b7c" ;
+      nie:title "failbox" ;
+      nie:hasPart <http://data.lblod.info/id/mailboxes/1> .
+  }
+}

--- a/config/migrations/20260415120000-seed-data-monitoring-scheduled-job.sparql
+++ b/config/migrations/20260415120000-seed-data-monitoring-scheduled-job.sparql
@@ -9,18 +9,18 @@ INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/system/jobs> {
     <http://data.lblod.info/id/scheduled-job/data-monitoring>
       a cogs:ScheduledJob ;
-      mu:uuid "data-monitoring-scheduled-job" ;
+      mu:uuid "803afaf2-ae52-4a56-ab47-b81460f9b5dd" ;
       task:operation <http://redpencil.data.gift/id/jobs/concept/JobOperation/dataMonitoring> ;
       task:schedule <http://data.lblod.info/id/schedule/data-monitoring> .
 
     <http://data.lblod.info/id/schedule/data-monitoring>
       a task:CronSchedule ;
-      mu:uuid "data-monitoring-schedule" ;
+      mu:uuid "aed50ca7-a321-4c06-a1dd-1929501d9204" ;
       schema:repeatFrequency "17 4 * * *" .
 
     <http://data.lblod.info/id/scheduled-task/data-monitoring>
       a task:ScheduledTask ;
-      mu:uuid "data-monitoring-scheduled-task" ;
+      mu:uuid "67b05f30-3121-41b4-af5b-55746331c25c" ;
       dct:isPartOf <http://data.lblod.info/id/scheduled-job/data-monitoring> ;
       dct:created "2026-04-13T00:00:00.000Z"^^xsd:dateTime ;
       dct:modified "2026-04-13T00:00:00.000Z"^^xsd:dateTime ;

--- a/config/migrations/20260415120000-seed-data-monitoring-scheduled-job.sparql
+++ b/config/migrations/20260415120000-seed-data-monitoring-scheduled-job.sparql
@@ -1,7 +1,9 @@
 PREFIX cogs: <http://vocab.deri.ie/cogs#>
 PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX schema: <http://schema.org/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/system/jobs> {
@@ -13,6 +15,16 @@ INSERT DATA {
 
     <http://data.lblod.info/id/schedule/data-monitoring>
       a task:CronSchedule ;
+      mu:uuid "data-monitoring-schedule" ;
       schema:repeatFrequency "17 4 * * *" .
+
+    <http://data.lblod.info/id/scheduled-task/data-monitoring>
+      a task:ScheduledTask ;
+      mu:uuid "data-monitoring-scheduled-task" ;
+      dct:isPartOf <http://data.lblod.info/id/scheduled-job/data-monitoring> ;
+      dct:created "2026-04-13T00:00:00.000Z"^^xsd:dateTime ;
+      dct:modified "2026-04-13T00:00:00.000Z"^^xsd:dateTime ;
+      task:index "0" ;
+      task:operation <http://redpencil.data.gift/id/jobs/concept/TaskOperation/dataMonitoring/runQueries> .
   }
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,3 +23,5 @@ services:
     restart: "no"
   op-public-consumer:
     restart: "no"
+  data-monitoring:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     restart: always
     logging: *default-logging
   database:
-    image: semtech/sparql-parser:0.0.10
+    image: semtech/sparql-parser:0.0.15
     environment:
       LISP_DYNAMIC_SPACE_SIZE: "8192"
     volumes:
@@ -240,6 +240,37 @@ services:
       DIRECT_DATABASE_ENDPOINT: "http://triplestore:8890/sparql"
     volumes:
       - ./data/files/consumer-files/submissions:/consumer-files/
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+  data-monitoring:
+    image: lblod/data-monitoring-service:0.1.0
+    environment:
+      JOB_CREATOR_URI: "http://data.lblod.info/services/id/data-monitoring-service"
+      DEFAULT_MU_AUTH_SCOPE: "http://services.semantic.works/data-monitoring"
+      ANOMALY_THRESHOLD_PERCENT: "10"
+      ANOMALY_COMPARISON_WINDOW: "5" # 5 days (5 runs, one run per day)
+      EMAIL_FROM: "noreply@lblod.info"
+      EMAIL_TO: "noreply@lblod.info"
+    volumes:
+      - ./config/data-monitoring/queries:/config/queries
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+  deliver-email:
+    image: redpencil/deliver-email-service:1.0.0
+    environment:
+      MAILBOX_URI: "http://data.lblod.info/id/mailboxes/1"
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+  scheduled-job-controller:
+    image: lblod/scheduled-job-controller-service:1.2.1
+    environment:
+      LOG_SPARQL_ALL: "false"
     labels:
       - "logging=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -268,9 +268,9 @@ services:
     restart: always
     logging: *default-logging
   scheduled-job-controller:
-    image: lblod/scheduled-job-controller-service:1.2.1
+    image: lblod/scheduled-job-controller-service:1.2.2
     environment:
-      LOG_SPARQL_ALL: "false"
+      LOG_SPARQL_ALL: "true"
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
Added https://github.com/lblod/data-monitoring-service

Waiting for initial feedback on this PR before adding CI/CD. So for now, you'll need to add this to `docker-compose.override.yml`

```
services:
  data-monitoring:
    image: semtech/mu-javascript-template:1.9.1
    environment:
      NODE_ENV: "development"
    volumes:
      - /path/to/data-monitoring-service/:/app/
 ```